### PR TITLE
Add acortalo.live bypass

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -532,6 +532,17 @@ if(document instanceof HTMLDocument)
 					},1000)
 				})
 			})
+			domainBypass(/acortalo\\.(live|xyz)/,()=>{
+				if(document.referrer.indexOf("megawarez")>-1)
+				{
+					const _ce=document.createElement
+					document.createElement=t=>{
+						let e=_ce.call(document,t)
+						e.submit=()=>safelyNavigate(data)
+						return e
+					}
+				}
+			})
 			//Insertion point 1 — insert bypasses running before the DOM is loaded above this comment
 			hrefBypass(/(njiir|healthykk|linkasm|dxdrive|getwallpapers)\\.com|punchsubs\\.net|k2s\\.cc|muhammadyoga\\.me|u\\.to|skiplink\\.io|firefaucet\\.win\\/l\\/|emulator\\.games\\/download\\.php/,()=>window.setInterval=f=>setInterval(f,1))
 			domainBypass(/(racaty|longfiles|filepuma|filehorse|portableapps)\\.com|indishare\\.org|datei\\.to/,()=>window.setTimeout=f=>setTimeout(f,1))


### PR DESCRIPTION
Related to: #686

> Link:
`https://acortalo.live/#!anFHUDd2OWJOZzRJeWpoRzhiNGMvTkt6RWg0K0pFc3pjOWcrcmRudHdKMFJ5QWZHRXU0Njc5aHQ4ajY3Wkh5Qw==`
Source:
`https://www.megawarez.org/nero-platinum-descargar-full/`

The acortalo.live link must be clicked from megawarez.org because this website uses a referrer.

Thank you for your great extension.