### PR TITLE
bypass for multiple domains

### DIFF
--- a/injection_script.js
+++ b/injection_script.js
@@ -1867,3 +1867,15 @@ ensureDomLoaded(()=>{
 	},100)
 	setTimeout(()=>clearInterval(dT),10000)
 })
+
+// bypass for multiple domains
+if (typeof estesite3 !== 'undefined' && document.querySelector(".DownloadButOff") && document.querySelector("#open")) {
+	$.get(estesite3, function( data ) {
+		$('#open').html(data);
+		
+		$('.DownloadButOn').each( function (index) {
+			this.target = "_self";
+			this.click();
+		});
+	});
+}


### PR DESCRIPTION
Some sites like:
http://filmesmega.net/rambo-ate-o-fim-dublado/
https://www.torrentmegafilmes.tv/zumbilandia-atire-duas-vezes-torrent-2019-dual-audio-5-1-dublado-bluray-4k-720p-1080p-download/
Among others, they use the same link protector but with different domains.
This script detects this protectors independently from the domain and bypasses.